### PR TITLE
Fix typos in ArchiveExtractor.java error messages

### DIFF
--- a/arduino-core/src/cc/arduino/utils/ArchiveExtractor.java
+++ b/arduino-core/src/cc/arduino/utils/ArchiveExtractor.java
@@ -164,7 +164,7 @@ public class ArchiveExtractor {
           while (stripPath > 0) {
             slash = name.indexOf("/", slash);
             if (slash == -1) {
-              throw new IOException("Invalid archive: it must contains a single root folder");
+              throw new IOException("Invalid archive: it must contain a single root folder");
             }
             slash++;
             stripPath--;
@@ -174,7 +174,7 @@ public class ArchiveExtractor {
 
         // Strip the common path prefix when requested
         if (!name.startsWith(pathPrefix)) {
-          throw new IOException("Invalid archive: it must contains a single root folder while file " + name + " is outside " + pathPrefix);
+          throw new IOException("Invalid archive: it must contain a single root folder while file " + name + " is outside " + pathPrefix);
         }
         name = name.substring(pathPrefix.length());
         if (name.isEmpty()) {
@@ -185,7 +185,7 @@ public class ArchiveExtractor {
         File outputLinkedFile = null;
         if (isLink) {
           if (!linkName.startsWith(pathPrefix)) {
-            throw new IOException("Invalid archive: it must contains a single root folder while file " + linkName + " is outside " + pathPrefix);
+            throw new IOException("Invalid archive: it must contain a single root folder while file " + linkName + " is outside " + pathPrefix);
           }
           linkName = linkName.substring(pathPrefix.length());
           outputLinkedFile = new File(destFolder, linkName);


### PR DESCRIPTION
Changed the word *contains* to *contain* in multiple error messages. For example:
>Invalid archive: it must contains a single root folder